### PR TITLE
SpellCheck

### DIFF
--- a/vm_install_haproxy_and_setting_net_para.sh
+++ b/vm_install_haproxy_and_setting_net_para.sh
@@ -33,7 +33,7 @@ sysctl net.ipv4.tcp_keepalive_time=5
 
 
 #install rsyslog so that it can log haproxy events
-yum instll -y rsyslog
+yum install -y rsyslog
 sed -i '/^\$ModLoad/d' /etc/rsyslog.conf
 sed -i '/^$UDPServerRun/d' /etc/rsyslog.conf
 sed -i '/^local0/d' /etc/rsyslog.conf


### PR DESCRIPTION
vm_install_haproxy_and_setting_net_para.sh has a spelling problem，can cause install fail，request with spelling fixed